### PR TITLE
Fix 'mix' variable name collision with mix(), fix clamp() argument order

### DIFF
--- a/Ls_Vignette.glsl
+++ b/Ls_Vignette.glsl
@@ -5,7 +5,7 @@ uniform float adsk_result_w, adsk_result_h;
 uniform float adsk_result_frameratio;
 uniform vec3 edgetint, midtint;
 uniform vec2 centre;
-uniform float radius, mix, abruptness, aspect;
+uniform float radius, mixamt, abruptness, aspect;
 uniform sampler2D front;
 uniform bool clampblack, applyoffset;
 
@@ -30,7 +30,7 @@ void main() {
   tocent.x *= aspect;
   float rad = length(tocent);
   rad /= radius;
-  float v = pow(cos(clamp(0.0, 3.1415926535/2.0, rad)), 4.0);
+  float v = pow(cos(clamp(rad, 0.0, 3.1415926535/2.0)), 4.0);
   v = smoothishstep(v, abruptness);
 
   vec3 o;
@@ -44,14 +44,14 @@ void main() {
     o = mix(o, o * (midtint + vec3(0.5)), v);
   }
 
-  o = mix(f, o, mix);
+  o = mix(f, o, mixamt);
 
   if(clampblack) {
     o = clamp(o, 0.0, 999999.0);
   }
   
   float m = v;
-  m = mix(1.0, m, mix);
+  m = mix(1.0, m, mixamt);
 
   gl_FragColor = vec4(o, m);
 }

--- a/Ls_Vignette.xml
+++ b/Ls_Vignette.xml
@@ -36,7 +36,7 @@ lewis@lewissaunders.com" Name="Vignette">
          </SubUniform>
       </Uniform>
 
-      <Uniform ResDependent="None" Max="1000000.0" Min="-1000000.0" Default="0.5" Inc="0.01" Tooltip="" Row="1" Col="3" Page="0" Type="float" ChannelName="Mix" DisplayName="Mix" Name="mix">
+      <Uniform ResDependent="None" Max="1000000.0" Min="-1000000.0" Default="0.5" Inc="0.01" Tooltip="" Row="1" Col="3" Page="0" Type="float" ChannelName="Mix" DisplayName="Mix" Name="mixamt">
       </Uniform>
 
       <Uniform Row="2" Col="3" Page="0" Default="True" Tooltip="Apply using addition instead of multiplication - more correct when grading in log and preserves highlights" Type="bool" ChannelName="Add_instead_of_mult" DisplayName="Apply as offset" Name="applyoffset">


### PR DESCRIPTION
The use of 'mix' as a variable name collides with the GLSL mix() function and breaks the shader, so I changed it to 'mixamt'.
The arguments to clamp() were in the wrong order causing a NaN and breaking the shader.
